### PR TITLE
Include ScanConfig attributes

### DIFF
--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -1,4 +1,4 @@
-from xml_utils import get_attribute, get_content_of, get_children_of, create_element, as_string, as_xml
+from xml_utils import get_attribute, get_content_of, get_children_of, create_element, as_string, as_xml, get_element
 
 class Range:
 	def __init__(self, start, end):
@@ -70,10 +70,15 @@ class SiteConfiguration(SiteBase):
 		config.description = get_content_of(xml_data, 'Description', config.description)
 		config.is_dynamic = get_attribute(xml_data, 'isDynamic', config.is_dynamic) in ['1', 'true', True]
 		config.hosts = [_host_to_object(host) for host in get_children_of(xml_data, 'Hosts')]
-		# TODO: figure out why I added these prints & deepcopy, then clean it up
-		#print config.hosts
-		#import copy
-		#print as_string(as_xml(copy.deepcopy(as_string(xml_data))))
+
+                #Use scanconfig elements for the SiteConfiguration
+                scanconfig = get_element(xml_data, "ScanConfig")
+                config.configid = scanconfig.get("configID")
+                config.configtemplateid = scanconfig.get("templateID")
+                config.configname = scanconfig.get("name")
+                config.configversion = scanconfig.get("configVersion")
+                config.configengineid = scanconfig.get("engineID")		
+		
 		return config
 
 	@staticmethod
@@ -122,17 +127,18 @@ class SiteConfiguration(SiteBase):
 		xml_alerting = create_element('Alerting')
 		xml_data.append(xml_alerting)
 
-		# TODO: !!!
-		attributes = {}
-		attributes['configID'] = 3
-		attributes['name'] = 'Full audit without Web Spider'
-		attributes['templateID'] = 'full-audit-without-web-spider'
-		attributes['engineID'] = 3
-		attributes['configVersion'] = 3
-		xml_scanconfig = create_element('ScanConfig')
-		xml_scheduling = create_element('Scheduling')
-		xml_scanconfig.append(xml_scheduling)
-		xml_data.append(xml_scanconfig)
+		#Include ScanConfig attributes
+                attributes = {}
+                attributes['configID'] = self.configid
+                attributes['name'] = self.configname
+                attributes['templateID'] = self.configtemplateid
+                attributes['engineID'] = self.configengineid
+                attributes['configVersion'] = self.configversion
+                xml_scanconfig = create_element('ScanConfig', attributes)
+                xml_scheduling = create_element('Scheduling')
+                xml_scanconfig.append(xml_scheduling)
+                xml_data.append(xml_scanconfig)
+
 
 		#TODO: implement the xxxPrivileges
 		print as_string(as_xml(as_string(xml_data)))

--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -129,11 +129,28 @@ class SiteConfiguration(SiteBase):
 
 		#Include ScanConfig attributes
 		attributes = {}
-		attributes['configID'] = self.configid
-		attributes['name'] = self.configname
-		attributes['templateID'] = self.configtemplateid
-		attributes['engineID'] = self.configengineid
-		attributes['configVersion'] = self.configversion
+		
+		try:
+			attributes['configID'] = self.configid
+		except AttributeError:
+			attributes['configID'] = 3
+		try:
+			attributes['name'] = self.configname
+		except AttributeError:
+			attributes['name'] = "Full audit without Web Spider"
+		try:	
+			attributes['templateID'] = self.configtemplateid
+		except AttributeError:
+			attributes['templateID'] = "full-audit-without-web-spider"
+		try:
+			attributes['engineID'] = self.configengineid
+		except AttributeError:
+			attributes['engineID'] = 3
+		try:
+			attributes['configVersion'] = self.configversion
+		except AttributeError:
+			attributes['configVersion'] = 3
+
 		xml_scanconfig = create_element('ScanConfig', attributes)
 		xml_scheduling = create_element('Scheduling')
 		xml_scanconfig.append(xml_scheduling)

--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -71,13 +71,13 @@ class SiteConfiguration(SiteBase):
 		config.is_dynamic = get_attribute(xml_data, 'isDynamic', config.is_dynamic) in ['1', 'true', True]
 		config.hosts = [_host_to_object(host) for host in get_children_of(xml_data, 'Hosts')]
 
-                #Use scanconfig elements for the SiteConfiguration
-                scanconfig = get_element(xml_data, "ScanConfig")
-                config.configid = scanconfig.get("configID")
-                config.configtemplateid = scanconfig.get("templateID")
-                config.configname = scanconfig.get("name")
-                config.configversion = scanconfig.get("configVersion")
-                config.configengineid = scanconfig.get("engineID")		
+		#Use scanconfig elements for the SiteConfiguration
+		scanconfig = get_element(xml_data, "ScanConfig")
+		config.configid = scanconfig.get("configID")
+		config.configtemplateid = scanconfig.get("templateID")
+		config.configname = scanconfig.get("name")
+		config.configversion = scanconfig.get("configVersion")
+		config.configengineid = scanconfig.get("engineID")		
 		
 		return config
 
@@ -128,16 +128,16 @@ class SiteConfiguration(SiteBase):
 		xml_data.append(xml_alerting)
 
 		#Include ScanConfig attributes
-                attributes = {}
-                attributes['configID'] = self.configid
-                attributes['name'] = self.configname
-                attributes['templateID'] = self.configtemplateid
-                attributes['engineID'] = self.configengineid
-                attributes['configVersion'] = self.configversion
-                xml_scanconfig = create_element('ScanConfig', attributes)
-                xml_scheduling = create_element('Scheduling')
-                xml_scanconfig.append(xml_scheduling)
-                xml_data.append(xml_scanconfig)
+		attributes = {}
+		attributes['configID'] = self.configid
+		attributes['name'] = self.configname
+		attributes['templateID'] = self.configtemplateid
+		attributes['engineID'] = self.configengineid
+		attributes['configVersion'] = self.configversion
+		xml_scanconfig = create_element('ScanConfig', attributes)
+		xml_scheduling = create_element('Scheduling')
+		xml_scanconfig.append(xml_scheduling)
+		xml_data.append(xml_scanconfig)
 
 
 		#TODO: implement the xxxPrivileges


### PR DESCRIPTION
Added representation for ScanConfig attributes in CreateFromXML
Added representation for said elements in the AsXML output

This addresses a problem we were having with saving modified SiteConfigurations.  Also mentioned in https://github.com/rapid7/nexpose-client-python/issues/6

ScanConfig attributes were not previously being saved as part of the SiteConfiguration item.  This change pulls in the configID, configVersion, engineID, name, and templateID in the CreateCromXML method.  These attributes were previously statically defined in the AsXML method, but were not being attached to the new element (previous line 132).  

This makes it work, but requires a few more params when creating a new site.  May want to add in defaults in AsXML if the attributes weren't parsed from an existing site.

You can test using the following snippet:

        site_cfg = nexpose.SiteConfiguration.Create()
        site_cfg.id = -1
        site_cfg.name = site_name
        site_cfg.description = site_desc
        site_cfg.configname = "Full audit without Web Spider"
        site_cfg.configid = 3
        site_cfg.configengineid = 3
        site_cfg.configversion = 3
        site_cfg.configtemplateid = "full-audit-without-web-spider"
        site_cfg.hosts.append(nexpose_site.Host("192.168.0.100"))
        session.SaveSiteConfiguration(site_cfg)


