### PR TITLE
Fix for GetFilteredAssets internal server error

### DIFF
--- a/nexpose/nexpose_assetfilter.py
+++ b/nexpose/nexpose_assetfilter.py
@@ -1,6 +1,7 @@
 from json_utils import JSON
 from nexpose_criteria import Criteria, Criterion
 from nexpose_asset import AssetBase
+import json
 
 class FilteredAsset(AssetBase, JSON):
 	@staticmethod
@@ -60,5 +61,5 @@ class AssetFilter(JSON):
 		js['dir'] = 'ASC'
 		js['sort'] = 'assetIP' # why can't we sort on ID?
 		js['table-id'] = 'assetfilter'
-		js['searchCriteria'] = self.criteria.as_json()
+		js['searchCriteria'] = json.dumps(self.criteria.as_json(), separators=(',', ':'))
 		return js


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Convert asset filter criteria to double-quoted json.

The double-quotes are required for Nexpose to be able to parse the criteria correctly, as of some recent version of Nexpose. Single-quoted json is not considered valid anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #5


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed the steps in #5 and verified the returned results had data. 

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
