### PR TITLE
Maintain alert settings when saving a site

### DIFF
--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -77,6 +77,7 @@ class SiteConfiguration(SiteBase):
         config.description = get_content_of(xml_data, 'Description', config.description)
         config.is_dynamic = get_attribute(xml_data, 'isDynamic', config.is_dynamic) in ['1', 'true', True]
         config.hosts = [_host_to_object(host) for host in get_children_of(xml_data, 'Hosts')]
+        config.alerting = [alert for alert in get_children_of(xml_data, 'Alerting')]
 
         #Use scanconfig elements for the SiteConfiguration
         scanconfig = get_element(xml_data, "ScanConfig")
@@ -106,7 +107,7 @@ class SiteConfiguration(SiteBase):
         self.is_dynamic = False
         self.hosts = []
         self.credentials = []  # TODO
-        self.alerting = []  # TODO
+        self.alerting = []
         self.scan_configuration = []  # TODO
         self.configid = self.id
         self.configtemplateid = "full-audit-without-web-spider"
@@ -139,6 +140,11 @@ class SiteConfiguration(SiteBase):
 
         xml_alerting = create_element('Alerting')
         xml_data.append(xml_alerting)
+
+        xml_alerts = create_element('Alerting')
+        for alert in self.alerting:
+            xml_alerts.append(alert)
+        xml_data.append(xml_alerts)
 
         #Include ScanConfig attributes
         attributes = {}

--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -139,12 +139,9 @@ class SiteConfiguration(SiteBase):
         xml_data.append(xml_credentials)
 
         xml_alerting = create_element('Alerting')
-        xml_data.append(xml_alerting)
-
-        xml_alerts = create_element('Alerting')
         for alert in self.alerting:
             xml_alerts.append(alert)
-        xml_data.append(xml_alerts)
+        xml_data.append(xml_alerting)
 
         #Include ScanConfig attributes
         attributes = {}


### PR DESCRIPTION
## Description
Existing site alerts are cleared when saving a configuration to a site.  This PR keeps those alert settings.

## Motivation and Context
Alerts are cleared when saving a configuration to a site....basically deleting them.

## How Has This Been Tested?
```
python -m pytest
=========================================================== test session starts ============================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/user/nexpose-client-python, inifile: 
collected 27 items 

tests/test_LoadFixture.py ...
tests/test_NexposeNode.py .
tests/test_NexposeReportConfigurationSummary.py ..
tests/test_NexposeSession.py ...........
tests/test_NexposeTag.py .....
tests/test_NexposeUserAuthenticatorSummary.py .
tests/test_NexposeVulnerability.py ....

======================================================== 27 passed in 0.23 seconds =========================================================
````

## Screenshots (if appropriate):

## Types of changes
Pulls existing alerts from site configuration and then re-populates xml form when submitting back to Nexpose.

## Checklist:
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

