### PR TITLE
Adding site schedule to Init, AsXML, and CreateFromXML

### DIFF
--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -86,6 +86,8 @@ class SiteConfiguration(SiteBase):
         config.configversion = scanconfig.get("configVersion")
         config.configengineid = scanconfig.get("engineID")
 
+        config.schedules = get_children_of(scanconfig, "Schedules")
+
         return config
 
     @staticmethod
@@ -113,6 +115,7 @@ class SiteConfiguration(SiteBase):
         self.configname = "Full audit without Web Spider"
         self.configversion = 3
         self.configengineid = 3
+        self.schedules = []
 
     def AsXML(self, exclude_id):
         attributes = {}
@@ -150,6 +153,8 @@ class SiteConfiguration(SiteBase):
 
         xml_scanconfig = create_element('ScanConfig', attributes)
         xml_scheduling = create_element('Scheduling')
+        for sched in self.schedules:
+            xml_scheduling.append(sched)
         xml_scanconfig.append(xml_scheduling)
         xml_data.append(xml_scanconfig)
 


### PR DESCRIPTION
## Description
Schedules were not being parsed from API responses into the SiteConfiguration.  This caused calls to SaveSite to remove any existing schedules.  This commit stores the schedule elements into the SiteConfiguration, and dumps them back in when AsXML is called.  

*Note*:  The Schedule XML elements remain as XML elements, they are not parsed into a dictionary attribute or anything.  This commit won't help much on creating or modifying schedules via the lib, but it makes it so that SaveSiteConfiguration doesn't destroy existing schedules.

## Motivation and Context
I want to be able to update assets within the site without removing scan schedules.

## How Has This Been Tested?
Created a scan schedule, used the library to modify the asset list, ensured that the previous schedules were not removed.

## Types of changes
Bug Fix


