### PR TITLE
Fix urllib imports by installing futures aliases earlier

### DIFF
--- a/nexpose/nexpose.py
+++ b/nexpose/nexpose.py
@@ -1,13 +1,11 @@
 # Future Imports for py2/3 backwards compat.
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 from builtins import object
+from future import standard_library
+standard_library.install_aliases()
 import urllib.request
 import urllib.parse
 import urllib.error
-import urllib.request
-import urllib.error
-import urllib.parse
 import base64
 import json
 from .json_utils import load_urls
@@ -39,8 +37,6 @@ from .nexpose_userauthenticator import UserAuthenticatorSummary
 from .nexpose_vulnerability import VulnerabilityReference, VulnerabilitySummary, VulnerabilityDetail
 from .nexpose_vulnerabilityexception import VulnerabilityExceptionStatus, VulnerabilityExceptionReason, VulnerabilityExceptionScope, SiloVulnerabilityExceptionDetails, VulnerabilityException
 from . import nexpose_criteria as Criteria
-from future import standard_library
-standard_library.install_aliases()
 
 DEFAULT_BLOCK_SIZE = 32768
 

--- a/nexpose/nexpose_discoveryconnection.py
+++ b/nexpose/nexpose_discoveryconnection.py
@@ -1,11 +1,10 @@
 # Future Imports for py2/3 backwards compat.
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 from builtins import object
-from .xml_utils import get_attribute, create_element
-from urllib.parse import urlparse
 from future import standard_library
 standard_library.install_aliases()
+from .xml_utils import get_attribute, create_element
+from urllib.parse import urlparse
 
 
 class DiscoveryConnectionProtocol(object):


### PR DESCRIPTION
## Description
Fixes #40 problem with importing on python 2

## How Has This Been Tested?
Built a wheel, installed to a new 2.7.13 virtualenv and executed `from nexpose import nexpose` in python interpreter.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] All new and existing tests passed.

