### PR TITLE
Improvements for AssetDetails, Tags & Unique Identifiers + Adhoc Reports

### DIFF
--- a/nexpose/json_utils.py
+++ b/nexpose/json_utils.py
@@ -28,7 +28,8 @@ def get_id(data, id_field_name):
     return data  # assume the data is the id
 
 
-def load_urls(json_dict, url_loader):
+def load_urls(json_dict, url_loader, ignore_error=False):
+    from urllib.error import HTTPError
     assert isinstance(json_dict, dict)
     for key in list(json_dict.keys()):
         if isinstance(json_dict[key], dict):
@@ -36,4 +37,8 @@ def load_urls(json_dict, url_loader):
                 raise ValueError('json_dict[' + key + '] already contains a json-element')
             url = json_dict[key].get('url', None)
             if url is not None:
-                json_dict[key]['json'] = url_loader(url)
+                try:
+                    json_dict[key]['json'] = url_loader(url)
+                except HTTPError:
+                    if not ignore_error:
+                        raise

--- a/nexpose/nexpose.py
+++ b/nexpose/nexpose.py
@@ -1412,6 +1412,10 @@ class NexposeSession(NexposeSession_APIv1d2):
             asset_or_id = asset_or_id.id
         sub_url = APIURL_ASSETS.format(asset_or_id)
         json_dict = self.ExecutePagedGet_v21(sub_url)
+        if 'tags' not in json_dict:
+            json_dict['tags'] = {
+                'url': json_dict['url'] + '/tags'
+            }
         load_urls(json_dict, self.ExecutePagedGet_v21, ignore_error=ignore_details_error)
         return AssetDetails.CreateFromJSON(json_dict)
 

--- a/nexpose/nexpose.py
+++ b/nexpose/nexpose.py
@@ -1403,7 +1403,7 @@ class NexposeSession(NexposeSession_APIv1d2):
         object_creator = lambda xml_data: AssetSummary.CreateFromXML(xml_data, site_id=xml_data.getparent().attrib['site-id'])
         return request_and_create_objects_from_xml(requestor, 'SiteDevices/device', object_creator)
 
-    def GetAssetDetails(self, asset_or_id):
+    def GetAssetDetails(self, asset_or_id, ignore_details_error=False):
         """
         Get detailed information of an asset.
         Requires the 2.1 API!
@@ -1412,7 +1412,7 @@ class NexposeSession(NexposeSession_APIv1d2):
             asset_or_id = asset_or_id.id
         sub_url = APIURL_ASSETS.format(asset_or_id)
         json_dict = self.ExecutePagedGet_v21(sub_url)
-        load_urls(json_dict, self.ExecutePagedGet_v21)
+        load_urls(json_dict, self.ExecutePagedGet_v21, ignore_error=ignore_details_error)
         return AssetDetails.CreateFromJSON(json_dict)
 
     def DeleteAsset(self, asset_or_id):

--- a/nexpose/nexpose_asset.py
+++ b/nexpose/nexpose_asset.py
@@ -6,6 +6,8 @@ from .xml_utils import get_attribute
 from future import standard_library
 standard_library.install_aliases()
 
+from .nexpose_tag import Tag
+
 
 class AssetHostTypes(object):
     Empty = ''
@@ -77,11 +79,30 @@ class AssetDetails(AssetBase):
             details.last_scan_id = assessment['last_scan_id']
             details.last_scan_date = assessment['last_scan_date']
 
+        try:
+            tags = json_dict['tags']['json']['resources']
+        except KeyError:
+            pass
+        else:
+            for tag in tags:
+                details.tags.append(Tag.CreateFromJSON(tag))
+
+        details.unique_identifiers = []
+        try:
+            unique_identifiers_data = json_dict['unique_identifiers']['json']
+        except KeyError:
+            # Unique Identifiers not fetched
+            pass
+        else:
+            for identifier in unique_identifiers_data:
+                details.unique_identifiers.append(
+                    UniqueIdentifier.CreateFromJSON(identifier)
+                )
+
         # TODO:
         # ----begin
         details.files = []
         details.vulnerability_instances = []
-        details.unique_identifiers = []
         details.group_accounts = []
         details.user_accounts = []
         details.vulnerabilities = []
@@ -110,3 +131,24 @@ class AssetDetails(AssetBase):
         self.vulnerabilities = []
         self.software = []
         self.services = []
+        self.tags = []
+
+
+class UniqueIdentifier(object):
+
+    def __init__(self):
+        self.source = ''
+        self.id = ''
+
+    @staticmethod
+    def CreateFromJSON(json_dict):
+        unique_identifier = UniqueIdentifier()
+        unique_identifier.source = json_dict['source']
+        unique_identifier.id = json_dict['id']
+        return unique_identifier
+
+    def __repr__(self):
+        return '<UniqueIdentifier {type}: {id}>'.format(
+            type=self.source,
+            id=self.id,
+        )

--- a/nexpose/nexpose_asset.py
+++ b/nexpose/nexpose_asset.py
@@ -22,7 +22,10 @@ class AssetBase(object):
 
     def InitializeFromJSON(self, json_dict):
         self.id = json_dict['id']
-        self.risk_score = json_dict['assessment']['json']['risk_score']
+        try:
+            self.risk_score = json_dict['assessment']['json']['risk_score']
+        except KeyError:
+            pass
 
     def __init__(self):
         self.id = 0
@@ -66,8 +69,14 @@ class AssetDetails(AssetBase):
             details.host_type = host_type
         details.os_name = json_dict["os_name"]
         details.os_cpe = json_dict["os_cpe"]
-        details.last_scan_id = json_dict['assessment']['json']['last_scan_id']
-        details.last_scan_date = json_dict['assessment']['json']['last_scan_date']
+        try:
+            assessment = json_dict['assessment']['json']
+        except KeyError:
+            pass
+        else:
+            details.last_scan_id = assessment['last_scan_id']
+            details.last_scan_date = assessment['last_scan_date']
+
         # TODO:
         # ----begin
         details.files = []


### PR DESCRIPTION
Tags & Unique Identifiers are now supported similar to the Ruby client. Adhoc reports can be generated in more than XML.

## Description
See commit messages for more details. They outline each change.

## Motivation and Context
These changes are needed for our use case of Nexpose. All changes are backwards-compatible improvements which is why they are in a PR.

## How Has This Been Tested?
No additional tests have been added but all changes have been verified and are being used by our code. All old tests still work (which is expected given that all changes are backwards-compatible). Changes have only been tested in Python 3. The only potential problem is the new CSV parsing function which has been explicitly tested & verified for Python 2 as well.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

There's no docs for any of the areas I touched so I didn't add any either. Same goes for tests.
