### PR TITLE
Add support for ESO API

### DIFF
--- a/nexpose/nexpose_eso.py
+++ b/nexpose/nexpose_eso.py
@@ -1,29 +1,105 @@
 import copy
+from .nexpose_integration_options import IntegrationOption, Step, StepConfiguration, ServiceNames
 
 
 class Configuration(object):
 
     @classmethod
-    def CreateFromJSON(cls, json_dict):
+    def CreateFromJSON(cls, json_dict, integration_options=None):
         services = {
             'amazon-web-services': AWSConfiguration,
         }
         service_name = json_dict['serviceName']
+        if integration_options is not None:
+            integration_options = [
+                IntegrationOption.CreateFromJSON(i) for i in integration_options]
         if service_name in services:
             cls = services[service_name]
-        config = cls(
-            service_name=json_dict['serviceName'],
-            name=json_dict['configName'],
-            properties=json_dict['configurationAttributes']['properties'],
-            id=json_dict['configID'],
-        )
+            config = cls(
+                name=json_dict['configName'],
+                properties=json_dict['configurationAttributes']['properties'],
+                id=json_dict['configID'],
+                integration_options=integration_options,
+            )
+        else:
+            config = cls(
+                service_name=json_dict['serviceName'],
+                name=json_dict['configName'],
+                properties=json_dict['configurationAttributes']['properties'],
+                id=json_dict['configID'],
+                integration_options=integration_options,
+            )
         return config
 
-    def __init__(self, service_name, name, properties, id=None):
-        self.id = id
+    def __init__(self, service_name, name, properties, steps, id=None):
+        self._id = id
         self.properties = copy.deepcopy(properties)
         self.service_name = service_name
         self.name = name
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._id = id
+
+    def add_property(self, name, prop, type_=None):
+        if type_ is None:
+            if isinstance(prop, bool):
+                type_ = 'Boolean'
+            elif isinstance(prop, int):
+                type_ = 'Integer'
+            elif isinstance(prop, str):
+                type_ = 'String'
+            elif isinstance(prop, list):
+                type_ = 'Array'
+            else:
+                raise TypeError("Invalid type {} for prop '{}'".format(type(prop), name))
+        data = {
+            'valueClass': type_,
+        }
+        if type_ == 'Array':
+            data['items'] = [{'value': v, 'valueClass': 'String'} for v in prop]
+        else:
+            data['value'] = prop
+        self.properties[name] = data
+
+    def get_property(self, name, default=None):
+        try:
+            prop = self.properties[name]
+        except KeyError:
+            if default is None:
+                raise
+            else:
+                self.add_property(name, default)
+                prop = self.properties[name]
+        if self.properties[name]['valueClass'] == 'Array':
+            prop = [p['value'] for p in prop['items']]
+        else:
+            prop = prop['value']
+        return prop
+
+    def add_property_item(self, name, item):
+        if item in self.get_property(name, []):
+            raise ValueError("{} '{}' already in configuration".format(name, item))
+        self.properties[name]['items'].append({'value': item, 'valueClass': 'String'})
+
+    def _get_step(self, option_name, service_name, type_name=None):
+        for opt in self._integration_options:
+            if option_name not in opt.name:
+                continue
+            try:
+                return opt.get_step(service_name, type_name)
+            except KeyError:
+                msg = "Unable to find step for option '{}', serviceName '{}'".format(
+                    option_name, service_name)
+                if type_name is not None:
+                    msg += " and typeName '{}'".format(type_name)
+                raise KeyError(msg)
+        else:
+            raise KeyError("Unknown option_name '{}'".format(option_name))
 
     def as_json(self):
         json_dict = {
@@ -35,82 +111,211 @@ class Configuration(object):
                 'properties': self.properties,
             },
         }
-        json_dict['configID'] = self.id
-
+        if self._id:
+            json_dict['configID'] = self.id
         return json_dict
 
 
+
+def _AWS_get_default_verify_opts():
+    return IntegrationOption(
+        name='aws-verify',
+        steps=[Step(
+           service_name=ServiceNames.AWS,
+           config=StepConfiguration(type_name='verify-aws-targets'),
+        ), Step(
+            service_name=ServiceNames.NEXPOSE,
+            config=StepConfiguration(
+                type_name='verify-external-targets',
+                previous_type_name='verify-aws-targets',
+            ),
+        ), Step(
+            service_name=ServiceNames.AWS,
+            config=StepConfiguration(
+                type_name='verify-aws-targets',
+                previous_type_name='verify-external-targets',
+            ),
+        )],
+    )
+
+
+def _AWS_get_default_sync_opts():
+    return IntegrationOption(
+        name='aws-sync',
+        steps=[Step(
+            service_name=ServiceNames.AWS,
+            config=StepConfiguration(
+                type_name='discover-aws-assets',
+            ),
+        ), Step(
+            service_name=ServiceNames.NEXPOSE,
+            config=StepConfiguration(
+                type_name='sync-external-assets',
+                previous_type_name='discover-aws-assets',
+            ),
+        )],
+    )
+
+
 class AWSConfiguration(Configuration):
+    service_name = ServiceNames.AWS
+
+    def __init__(self, name, properties=None, integration_options=None, id=None):
+        if properties is None:
+            properties = {}
+            """
+            properties = {
+                'arn': {
+                    'value': '',
+                     'valueClass': 'String',
+                },
+                 'consoleInsideAWS': {
+                    'value': False, 'valueClass': 'Boolean',
+                },
+                 'engineInsideAWS': {
+                    'value': False, 'valueClass': 'Boolean',
+                },
+                 'region': {
+                    'items': [],
+                    'valueClass': 'Array',
+                },
+                 'sessionName': {
+                    'value': '', 'valueClass': 'String',
+                },
+                 'useProxy': {
+                    'value': False, 'valueClass': 'Boolean',
+                },
+            }
+            """
+        if integration_options is None:
+            integration_options = []
+        self._id = None
+
+        self.name = name
+        self._integration_options = integration_options
+        self.properties = properties
+        if id is not None:
+            self.id = id
+
+    def enable_default_integrations(self, site_id, import_tags=False):
+        self._integration_options += [
+            _AWS_get_default_sync_opts(),
+            _AWS_get_default_verify_opts(),
+        ]
+        self.site_id = site_id
+        self.import_tags = import_tags
 
     @property
-    def region(self):
-        items = self.properties['region']['items']
-        regions = [i['value'] for i in items]
-        return regions
+    def id(self):
+        return self._id
 
-    @region.setter
-    def region(self, regions):
-        items = [{'valueClass': 'String', 'value': r} for r in regions]
-        self.properties['region']['items'] = items
+    @id.setter
+    def id(self, value):
+        self._id = value
+        for opt in self._integration_options:
+            if 'Config ID' not in opt.name:
+                opt.name = "Config ID:{} - {}".format(value, opt.name)
+            for step in opt.steps:
+                if step.service_name != ServiceNames.AWS:
+                    continue
+                step.config.add_property('discoveryConfigID', value)
+
+    #
+    # Properties stored directly on AWSConfiguration
+    #
+
+    @property
+    def regions(self):
+        return self.get_property('region')
+
+    @regions.setter
+    def regions(self, regions):
+        self.add_property('region', list(regions))
 
     def add_region(self, region):
-        if region in self.region:
-            raise RuntimeError("Region {} already in configuration".format(region))
-        self.properties['region']['items'].append(
-            {'valueClass': 'String', 'value': region})
+        self.add_property_item('region', region)
 
     @property
     def engine_inside_aws(self):
-        return self.properties['engineInsideAWS']['value']
+        return self.get_property('engineInsideAWS')
 
     @engine_inside_aws.setter
     def engine_inside_aws(self, value):
-        self.properties['engineInsideAWS']['value'] = value
-
-    @property
-    def import_tags(self):
-        return self.properties['importTags']['value']
-
-    @import_tags.setter
-    def import_tags(self, value):
-        self.properties['importTags']['value'] = value
+        self.add_property('engineInsideAWS', bool(value))
 
     @property
     def console_inside_aws(self):
-        return self.properties['consoleInsideAWS']['value']
+        return self.get_property('consoleInsideAWS')
 
     @console_inside_aws.setter
     def console_inside_aws(self, value):
-        self.properties['consoleInsideAWS']['value'] = value
+        self.add_property('consoleInsideAWS', bool(value))
 
     @property
     def session_name(self):
-        return self.properties['sessionName']['value']
+        return self.get_property('sessionName')
 
     @session_name.setter
     def session_name(self, value):
-        self.properties['sessionName']['value'] = value
-
-    @property
-    def site_id(self):
-        return self.properties['siteID']['value']
-
-    @site_id.setter
-    def site_id(self, value):
-        self.properties['siteID']['value'] = str(value)
+        self.add_property('sessionName', str(value))
 
     @property
     def use_proxy(self):
-        return self.properties['useProxy']['value']
+        return self.get_property('useProxy')
 
     @use_proxy.setter
     def use_proxy(self, value):
-        self.properties['useProxy']['value'] = value
+        self.add_property('useProxy', bool(value))
 
     @property
     def arn(self):
-        return self.properties['arn']['value']
+        return self.get_property('arn')
 
     @arn.setter
     def arn(self, value):
-        self.properties['arn']['value'] = value
+        self.add_property('arn', str(value))
+
+
+    #
+    # Properties stored on some steps
+    #
+
+    @property
+    def import_tags(self):
+        step = self._get_step(
+            'aws-sync',
+            'amazon-web-services',
+            'discover-aws-assets',
+        )
+        return step.config.get_property('importTags')
+
+    @import_tags.setter
+    def import_tags(self, value):
+        step = self._get_step(
+            'aws-sync',
+            'amazon-web-services',
+            'discover-aws-assets',
+        )
+        step.config.add_property('importTags', bool(value))
+
+    @property
+    def site_id(self):
+        step = self._get_step(
+            'aws-sync',
+            'nexpose',
+            'sync-external-assets',
+        )
+        return step.config.get_property('siteID')
+
+    @site_id.setter
+    def site_id(self, value):
+        step = self._get_step(
+            'aws-sync',
+            'nexpose',
+            'sync-external-assets',
+        )
+        return step.config.add_property('siteID', int(value))
+
+    @property
+    def integration_options(self):
+        return self._integration_options

--- a/nexpose/nexpose_eso.py
+++ b/nexpose/nexpose_eso.py
@@ -244,12 +244,15 @@ class AWSConfiguration(Configuration):
         self.add_property('useProxy', bool(value))
 
     @property
-    def arn(self):
+    def arns(self):
         return self.get_property('arn')
 
-    @arn.setter
-    def arn(self, value):
-        self.add_property('arn', str(value))
+    @arns.setter
+    def arns(self, arns):
+        self.add_property('arn', list(arns))
+
+    def add_arn(self, arn):
+        self.add_property_item('arn', arn)
 
 
     #

--- a/nexpose/nexpose_eso.py
+++ b/nexpose/nexpose_eso.py
@@ -1,0 +1,116 @@
+import copy
+
+
+class Configuration(object):
+
+    @classmethod
+    def CreateFromJSON(cls, json_dict):
+        services = {
+            'amazon-web-services': AWSConfiguration,
+        }
+        service_name = json_dict['serviceName']
+        if service_name in services:
+            cls = services[service_name]
+        config = cls(
+            service_name=json_dict['serviceName'],
+            name=json_dict['configName'],
+            properties=json_dict['configurationAttributes']['properties'],
+            id=json_dict['configID'],
+        )
+        return config
+
+    def __init__(self, service_name, name, properties, id=None):
+        self.id = id
+        self.properties = copy.deepcopy(properties)
+        self.service_name = service_name
+        self.name = name
+
+    def as_json(self):
+        json_dict = {
+            'serviceName': self.service_name,
+            'configName': self.name,
+            'configurationAttributes': {
+                'valueClass': 'Object',
+                'objectType': 'service_configuration',
+                'properties': self.properties,
+            },
+        }
+        json_dict['configID'] = self.id
+
+        return json_dict
+
+
+class AWSConfiguration(Configuration):
+
+    @property
+    def region(self):
+        items = self.properties['region']['items']
+        regions = [i['value'] for i in items]
+        return regions
+
+    @region.setter
+    def region(self, regions):
+        items = [{'valueClass': 'String', 'value': r} for r in regions]
+        self.properties['region']['items'] = items
+
+    def add_region(self, region):
+        if region in self.region:
+            raise RuntimeError("Region {} already in configuration".format(region))
+        self.properties['region']['items'].append(
+            {'valueClass': 'String', 'value': region})
+
+    @property
+    def engine_inside_aws(self):
+        return self.properties['engineInsideAWS']['value']
+
+    @engine_inside_aws.setter
+    def engine_inside_aws(self, value):
+        self.properties['engineInsideAWS']['value'] = value
+
+    @property
+    def import_tags(self):
+        return self.properties['importTags']['value']
+
+    @import_tags.setter
+    def import_tags(self, value):
+        self.properties['importTags']['value'] = value
+
+    @property
+    def console_inside_aws(self):
+        return self.properties['consoleInsideAWS']['value']
+
+    @console_inside_aws.setter
+    def console_inside_aws(self, value):
+        self.properties['consoleInsideAWS']['value'] = value
+
+    @property
+    def session_name(self):
+        return self.properties['sessionName']['value']
+
+    @session_name.setter
+    def session_name(self, value):
+        self.properties['sessionName']['value'] = value
+
+    @property
+    def site_id(self):
+        return self.properties['siteID']['value']
+
+    @site_id.setter
+    def site_id(self, value):
+        self.properties['siteID']['value'] = str(value)
+
+    @property
+    def use_proxy(self):
+        return self.properties['useProxy']['value']
+
+    @use_proxy.setter
+    def use_proxy(self, value):
+        self.properties['useProxy']['value'] = value
+
+    @property
+    def arn(self):
+        return self.properties['arn']['value']
+
+    @arn.setter
+    def arn(self, value):
+        self.properties['arn']['value'] = value

--- a/nexpose/nexpose_eso.py
+++ b/nexpose/nexpose_eso.py
@@ -163,30 +163,6 @@ class AWSConfiguration(Configuration):
     def __init__(self, name, properties=None, integration_options=None, id=None):
         if properties is None:
             properties = {}
-            """
-            properties = {
-                'arn': {
-                    'value': '',
-                     'valueClass': 'String',
-                },
-                 'consoleInsideAWS': {
-                    'value': False, 'valueClass': 'Boolean',
-                },
-                 'engineInsideAWS': {
-                    'value': False, 'valueClass': 'Boolean',
-                },
-                 'region': {
-                    'items': [],
-                    'valueClass': 'Array',
-                },
-                 'sessionName': {
-                    'value': '', 'valueClass': 'String',
-                },
-                 'useProxy': {
-                    'value': False, 'valueClass': 'Boolean',
-                },
-            }
-            """
         if integration_options is None:
             integration_options = []
         self._id = None

--- a/nexpose/nexpose_integration_options.py
+++ b/nexpose/nexpose_integration_options.py
@@ -45,6 +45,7 @@ class StepConfiguration(object):
             set_defaults=False,
             integration_option_id=integration_option_id)
         step_config.configuration_params['properties'] = props
+        return step_config
 
     def __init__(
             self, type_name, previous_type_name="",

--- a/nexpose/nexpose_integration_options.py
+++ b/nexpose/nexpose_integration_options.py
@@ -1,0 +1,153 @@
+class ServiceNames(object):
+    AWS = 'amazon-web-services'
+    NEXPOSE = 'nexpose'
+
+
+class Step(object):
+    
+    @classmethod
+    def CreateFromJSON(cls, json_dict):
+        uuid = json_dict.get('uuid')
+        service_name = json_dict['serviceName']
+        config = StepConfiguration.CreateFromJSON(
+            json_dict['stepConfiguration'])
+        return cls(
+            service_name=service_name,
+            config=config,
+            uuid=uuid,
+        )
+
+    def __init__(self, service_name, config, uuid=None):
+        self.uuid = uuid
+        self.service_name = service_name
+        self.config = config
+
+    def as_json(self):
+        data = {
+            "serviceName": self.service_name,
+            "stepConfiguration": self.config.as_json(),
+        }
+        if self.uuid is not None:
+            data['uuid'] = self.uuid,
+        return data
+
+
+class StepConfiguration(object):
+
+    @classmethod
+    def CreateFromJSON(cls, json_dict):
+        type_name = json_dict['typeName']
+        previous_type_name = json_dict.get('previousTypeName', "")
+        props = json_dict.get('configurationParams', {}).get('properties', {})
+        integration_option_id = json_dict.get('integrationOptionID')
+        step_config = cls(
+            type_name, previous_type_name,
+            set_defaults=False,
+            integration_option_id=integration_option_id)
+        step_config.configuration_params['properties'] = props
+
+    def __init__(
+            self, type_name, previous_type_name="",
+            set_defaults=True,
+            workflow_id=None, integration_option_id=None, **properties):
+        self.type_name = type_name
+        self.previous_type_name = previous_type_name
+        if properties is None:
+            properties = {}
+        self.configuration_params = {
+            "valueClass": "Object",
+            "objectType": "params",
+            "properties": {},
+        }
+        for prop_name, prop_value in properties.items():
+            self.add_property(prop_name, prop_value)
+        self.workflow_id = workflow_id
+        self.integration_option_id = integration_option_id
+        if set_defaults:
+            self.set_defaults()
+
+    def set_defaults(self):
+        defaults = {}
+        if self.type_name == 'discover-aws-assets':
+            defaults = {
+                'excludeAssetsWithTags': '',
+                'importTags': False,
+                'onlyImportTheseTags': '',
+            }
+        for prop_name, default_value in defaults.items():
+            if prop_name not in self.configuration_params['properties']:
+                self.add_property(prop_name, default_value)
+
+    def add_property(self, name, prop, type_=None):
+        if type_ is None:
+            if isinstance(prop, bool):
+                type_ = 'Boolean'
+            elif isinstance(prop, int):
+                type_ = 'Integer'
+            elif isinstance(prop, str):
+                type_ = 'String'
+            else:
+                raise TypeError("Invalid type {} for prop '{}'".format(type(prop), name))
+        self.configuration_params['properties'][name] = {
+            'valueClass': type_,
+            'value': prop,
+        }
+
+    def get_property(self, name):
+        return self.configuration_params['properties'][name]['value']
+
+    def as_json(self):
+        data = {
+            "typeName": self.type_name,
+            "previousTypeName": self.previous_type_name,
+            "configurationParams": self.configuration_params,
+        }
+        if self.workflow_id:
+            data['workflowID'] = self.workflow_id
+        if self.integration_option_id:
+            data['integrationOptionID'] = self.integration_option_id
+        return data
+
+
+class IntegrationOption(object):
+
+    @classmethod
+    def CreateFromJSON(cls, json_dict):
+        name = json_dict.get('name', "")
+        id_ = json_dict.get('id')
+        steps = [Step.CreateFromJSON(s) for s in json_dict['steps']]
+        return cls(name, id_, steps)
+
+    def __init__(self, name="", id=None, steps=None):
+        if steps is None:
+            steps = []
+        self.name = name
+        self.id = id
+        self.steps = steps
+
+    def get_step(self, service_name, type_name=None):
+        for step in self.steps:
+            if step.service_name != service_name:
+                continue
+            if type_name is not None and step.config.type_name != type_name:
+                continue
+            return step
+        else:
+            msg = "Unable to find step for serviceName '{}'".format(
+                service_name)
+            if type_name is not None:
+                msg += " and typeName '{}'".format(type_name)
+            raise KeyError(msg)
+
+    def as_json(self):
+        data = {
+            'name': self.name,
+            'steps': [s.as_json() for s in self.steps]
+        }
+        if self.id is not None:
+            data['id'] = self.id
+        return data
+
+    def update(self, data):
+        self.id = data['id']
+        self.steps = [Step.CreateFromJSON(s) for s in data['steps']]

--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -170,7 +170,7 @@ class SiteConfiguration(SiteBase):
         attributes['configVersion'] = self.configversion
 
         xml_scanconfig = create_element('ScanConfig', attributes)
-        xml_scheduling = create_element('Scheduling')
+        xml_scheduling = create_element('Schedules')
         for schedule in self.schedules:
             xml_scheduling.append(schedule)
         xml_scanconfig.append(xml_scheduling)

--- a/nexpose/nexpose_vulnerabilityexception.py
+++ b/nexpose/nexpose_vulnerabilityexception.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from builtins import object
-from .xml_utils import get_attribute, get_content_of
+from .xml_utils import get_attribute, get_content_of, create_element
 from future import standard_library
 standard_library.install_aliases()
 
@@ -68,6 +68,35 @@ class VulnerabilityException(object):
         details.asset_id = int(fix_null(get_attribute(xml_data, 'device-id', details.asset_id)))
         details.asset_port = int(fix_null(get_attribute(xml_data, 'port-no', details.asset_port)))
         return details
+
+    def AsXML(self):
+        attributes = {
+            'exception-id': self.id,
+            'vuln-id': self.vulnerability_id,
+            'vuln-key': self.vulnerability_key,
+            'submitter': self.submitter,
+            'reviewer': self.reviewer,
+            'status': self.status,
+            'reason': self.reason,
+            'scope': self.scope,
+        }
+        if self.expiration_date:
+            attributes['expiration-date'] = self.expiration_date
+        if self.asset_id:
+            attributes['asset-id'] = self.asset_id
+        if self.asset_port:
+            attributes['port-no'] = self.asset_port
+        xml_data = create_element('VulnerabilityException', attributes)
+        if self.submitter_comment:
+            submitter_comment = create_element('submitter-comment')
+            submitter_comment.text = self.submitter_comment
+            xml_data.append(submitter_comment)
+        if self.reviewer_comment:
+            reviewer_comment = create_element('reviewer-comment')
+            reviewer_comment.text = self.reviewer_comment
+            xml_data.append(reviewer_comment)
+        return xml_data
+
 
     def __init__(self):
         self.id = 0


### PR DESCRIPTION
This mirrors the changes in https://github.com/rapid7/nexpose-client/pull/309 but limited to
discovery connections.

## Description
Implement support for ESO API for discovery connections. Based on @hwilson-r7's changes in https://github.com/rapid7/nexpose-client/pull/309

- Add new functions to the client to talk to the ESO API
- Add new functions using the API for management of discovery connections
- Add new JSON HTTP request functions where they differ from their old usage
- Add generic `EsoConfiguration` class to handle all types of configuration
- Add specific support for `AWSConfiguration` class to address that particular use case.
- The two changes above both allow for an easy use of the API generically but also to handle AWS much more conveniently. This makes it extensible & it should be extended before using other types of connections.

Looking for feedback on whether this is the way you'd like this implemented or if changes are needed.

## Motivation and Context
This API is new and there is no support for it yet. We're looking at using it.

## How Has This Been Tested?
I created a test script that runs through most functionality. The following things are known issues:

- Preview does not work, it gives an error 500
- Error handling is not perfect - the client catches an error 500 very far down in the stack but the API will expose proper error messages. Potentially, the API should send 4XX errors as they indicate an error on the clients' side (and a 500 as it's being thrown indicates something the user can't fix). Error messages such as "this already exists" are 4XX but the server returns 500. If the server won't change, this will need updating.

The following things have been tested and work:
- Listing connections, types, etc.
- Saving a new & existing connection
- Deleting a connection
- Testing a connection
- Adding a second region to an existing site (for AWS)
- Everything above has only been tested in the context of AWS but _should_ work generically as far as I can tell

A recent update does also seem to cause 401s unless `X-Requested-With: XMLHttpRequest` HTTP headers are sent. This seems like a weird bug introduced in [6.4.66](https://help.rapid7.com/insightvm/en-us/release-notes/index.html?pid=6.4.66&cid=723680177) so I didn't include it in the PR, assuming it'll go away once fixed there.

No unit tests have been written.

This is the function used to test things:

````
    print(client.GetEsoServices())
    print(client.GetEsoConfigurationType('amazon-web-services'))
    configs = client.GetEsoServiceConfigurations('amazon-web-services')
    for config in configs:
        print(config.name, config.id)
    configs = {c.name.lower(): c for c in configs}
    config = client.GetEsoServiceConfigurationByName('amazon-web-services', config.name)
    print(config.name, config.id)
    config = client.GetEsoServiceConfiguration(config.id)
    print(config.name, config.id)
    print(client.TestEsoServiceConfiguration(config))
    print(client.PreviewEsoServiceConfiguration(config))
    config.add_region('Asia Pacific (Sydney)')
    config_id = client.SaveEsoServiceConfiguration(config)
    assert config_id == config.id
    assert config.id
    print(config.name, config.id)
    """
    client.DeleteEsoServiceConfiguration(config)
    print('Deleted config {}'.format(config.id))
    """
````

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

