### PR TITLE
Set name to "Schedules" correctly

### DIFF
--- a/nexpose/nexpose_site.py
+++ b/nexpose/nexpose_site.py
@@ -170,7 +170,7 @@ class SiteConfiguration(SiteBase):
         attributes['configVersion'] = self.configversion
 
         xml_scanconfig = create_element('ScanConfig', attributes)
-        xml_scheduling = create_element('Scheduling')
+        xml_scheduling = create_element('Schedules')
         for schedule in self.schedules:
             xml_scheduling.append(schedule)
         xml_scanconfig.append(xml_scheduling)


### PR DESCRIPTION
The old value used was "Scheduling" which is not documented anywhere
("Schedule" is the documented value). The parsing function
(CreateFromXML) uses "Schedule" as that's what the server sends. This
makes the other direction (AsXML) consistent. The server accepts this
value.

